### PR TITLE
fix get_size

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -1104,7 +1104,7 @@ Status PosixRandomRWFile::GetSizeOnDisk(uint64_t* size) {
   }
   assert(ret == 0);
 
-  *size = stat_buf.st_blocks * stat_buf.st_blksize;
+  *size = stat_buf.st_blocks * 512;
   return Status::OK();
 }
 


### PR DESCRIPTION
st_blocks is the number of 512B blocks allocated, and st_blksize is 4K normally.
Using st_blksize will get the wrong size.